### PR TITLE
Add support chaining

### DIFF
--- a/Sources/Fallback.swift
+++ b/Sources/Fallback.swift
@@ -89,3 +89,50 @@ public func fallback<T>(
     throw error
   }
 }
+
+public enum Tryable<T> {
+  case success(T)
+  case failure(Error)
+
+  public func `catch`(_ closure: @escaping (Error) throws -> T) -> Tryable<T> {
+    switch self {
+    case .success:
+      return self
+
+    case .failure(let error):
+      do {
+        return .success(try closure(error))
+      } catch (let error) {
+        return .failure(error)
+      }
+    }
+  }
+
+  public func rethrow() throws -> T {
+    switch self {
+    case .success(let value):
+      return value
+
+    case .failure(let error):
+      throw error
+    }
+  }
+
+  public func finally(_ closure: @escaping (Error) -> T) -> T {
+    switch self {
+    case .success(let value):
+      return value
+
+    case .failure(let error):
+      return closure(error)
+    }
+  }
+}
+
+public func fallback<T>(_ closure: () throws -> T) -> Tryable<T> {
+  do {
+    return .success(try closure())
+  } catch (let error) {
+    return .failure(error)
+  }
+}


### PR DESCRIPTION
This is for whom wants handle each errors.

From the [comment](https://www.reddit.com/r/swift/comments/59goaa/syntactic_sugar_for_swift_dotrycatch/#thing_t1_d98vhb5) from Reddit:

> Keeps it short and sweet. My biggest concern is that it's limiting errors to control flow. If get("A") and get("B") fail and we get("C") instead, what happened to the errors from the previous 2 calls? It looks to me like it only throws the last error.
### Examples

``` swift
let value: String = fallback {
  return try get("a")
}.catch { error in // error from "a"
  return try get("b")
}.catch { error in // error from "b"
  return try get("c")
}.finally { error in // error from "c"
  return "none"
}
print(value) // "none"
```

``` swift
let value: String = try fallback {
  return try get("a")
}.catch { error in // error from "a"
  return try get("b")
}.catch { error in // error from "b"
  return try get("c")
}.rethrow() // will throw error from "c"
```
### To Do
- [x] Implement
- [x] Test
- [ ] Documentation
